### PR TITLE
Implement ::lock! and #lock! methods

### DIFF
--- a/spec/redis_mutex_spec.rb
+++ b/spec/redis_mutex_spec.rb
@@ -93,4 +93,20 @@ describe Redis::Mutex do
       t2.join
     end
   end
+
+  describe '::lock!' do
+    it 'should not raise error if lock obtained' do
+      expect { Redis::Mutex.lock!(:test_lock) }.to_not raise_error
+    end
+
+    it 'should return value of block if lock obtained' do
+      Redis::Mutex.lock!(:test_lock) { :test_result }.should == :test_result
+    end
+
+    it 'should raise error if lock not obtained' do
+      Redis::Mutex.lock(:test_lock)
+      expect { Redis::Mutex.lock!(:test_lock) }.
+        to raise_error(Redis::Mutex::LockNotAcquired)
+    end
+  end
 end


### PR DESCRIPTION
Howdy -- I love the library, very nice and clean implementation of the approach laid out in the Redis docs. For our particular use case, it would be most useful to have a method that returns the value of the block passed if the lock is successfully acquired, and raises an error if not. In this patch I've added a `#lock!` method to do just that. Thanks for taking a look!
Mat
