### PR TITLE
- Remove `redis-classy` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,26 @@ gem 'redis-mutex'
 Register the Redis server: (e.g. in `config/initializers/redis_mutex.rb` for Rails)
 
 ```ruby
-Redis::Classy.db = Redis.new(:host => 'localhost')
+Redis::Mutex.default_redis = Redis.new(:host => 'localhost')
 ```
 
-Note that Redis Mutex uses the `redis-classy` gem internally to organize keys in an isolated namespace.
+You can also use a `Redis` object when using the `Redis::Mutex`,
+passing a `:redis` value in the options hash:
+
+
+```Ruby
+Redis::Mutex.with_lock("lock-key", :redis => Redis.new(:host => 'localhost')) do
+    # Do something
+end
+```
+
+Or:
+
+```Ruby
+Redis::Mutex.new("lock-key", :redis => Redis.new(:host => 'localhost')).with_lock do
+    # Do Something
+end
+```
 
 There are a number of methods:
 

--- a/lib/redis-mutex.rb
+++ b/lib/redis-mutex.rb
@@ -1,4 +1,4 @@
-require 'redis-classy'
+require 'redis-namespace'
 
 class Redis
   autoload :Mutex, 'redis/mutex'

--- a/redis-mutex.gemspec
+++ b/redis-mutex.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "redis-mutex"
   gem.require_paths = ["lib"]
-  gem.version       = '2.1.1' # retrieve this value by: Gem.loaded_specs['redis-mutex'].version.to_s
+  gem.version       = '3.0.0' # retrieve this value by: Gem.loaded_specs['redis-mutex'].version.to_s
 
-  gem.add_runtime_dependency "redis-classy", "~> 1.2"
+  gem.add_runtime_dependency "redis-namespace", "~> 1.0"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "bundler"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,15 @@ require 'rspec'
 require 'redis-mutex'
 
 RSpec.configure do |config|
-  # Use database 15 for testing so we don't accidentally step on you real data.
-  Redis::Classy.db = Redis.new(:db => 15)
-  unless Redis::Classy.keys.empty?
+  config.add_setting :redis_connection
+
+  redis = Redis.new(:db => 15)
+  Redis::Mutex.default_redis = redis
+
+  unless redis.keys.empty?
     puts '[ERROR]: Redis database 15 not empty! If you are sure, run "rake flushdb" beforehand.'
     exit!
   end
+
+  config.before(:suite) { RSpec.configuration.redis_connection = redis }
 end


### PR DESCRIPTION
Hello,

First of all, thank you for developing this gem, it's really useful
and seems to cover all the tricky cases. Test coverage is also very
good, which made this refactoring possible.

This pull request introduces the following changes:
- Remove `redis-classy` dependency
- Add the possibility to use a custom redis connection and not one
  saved in a class variable.  This makes the use of connection pools
  in redis apps possible, for example.
- The old API remains unchanged, although the initialization needs to
  be different since we can avoid saving a redis instance in a class
  variable, which I strongly advice against.

The reasons for this pull request are as follows:
1. With the current version, a redis connection is saved to an
   instance variable in Redis::Classy.

This makes the use of connection pools in redis applications
impossible because the connection used by Redis::Mutex is always the
one saved in a class variable.

This implementation is not thread safe and it's not possible to use
more than one redis connection with Redis::Mutex.

This is important because many times when you use a Mutex you have a
high number of concurrent operations and you probably need to use
multiple redis connections.
1. IMHO, `redis-classy` introduces too much meta programming and makes
   the code hard to read, when there is no need for it.

`redis-classy` makes the `Redis::Mutex` class behave exactly like a
redis connection, which I think is not at all the intention of a
`Redis::Mutex` class. This class should provide an API to use mutexes,
not to use redis. You could actually call redis operations (get, set,
etc etc) on `Redis::Mutex`
1. The new implementation is still not thread safer, but since each
   `Redis::Mutex` instance can receive it's own `Redis` instance, it's
   possible to implement a thread safe distributed mutex.

I will update the README further if you think this pull request can be accepted.
