### PR TITLE
reload object after lock if respond_to? :reload

### DIFF
--- a/lib/redis/mutex.rb
+++ b/lib/redis/mutex.rb
@@ -17,8 +17,11 @@ class Redis
     UnlockError = Class.new(StandardError)
     AssertionError = Class.new(StandardError)
 
+    attr_reader :object
+
     def initialize(object, options={})
       super(object.is_a?(String) || object.is_a?(Symbol) ? object : "#{object.class.name}:#{object.id}")
+      @object = object
       @block = options[:block] || 1
       @sleep = options[:sleep] || 0.1
       @expire = options[:expire] || DEFAULT_EXPIRE
@@ -39,6 +42,7 @@ class Redis
         # Non-blocking mode
         @locking = try_lock
       end
+      object.reload if @locking && object.respond_to?(:reload)
       @locking
     end
 

--- a/spec/redis_mutex_spec.rb
+++ b/spec/redis_mutex_spec.rb
@@ -22,6 +22,29 @@ describe Redis::Mutex do
     Redis::Classy.quit
   end
 
+  it 'sets the object' do
+    mutex = Redis::Mutex.new(:object)
+    expect(mutex.object).to eq :object
+  end
+
+  describe '#with_lock' do
+    it 'reloads the object if its reloadable' do
+      object = double("active_record_object", reload: true, id: "asdf")
+
+      expect(object).to receive(:reload)
+
+      Redis::Mutex.with_lock(object) {}
+    end
+    it "doesn't reload the object if it isn't reloadable" do
+      object = double("non_reloading_object", id: "asdf")
+      object.stub(:respond_to?).with(:reload).and_return(false)
+
+      expect(object).to_not receive(:reload)
+
+      Redis::Mutex.with_lock(object) {}
+    end
+  end
+
   it 'locks the universe' do
     mutex1 = Redis::Mutex.new(:test_lock, SHORT_MUTEX_OPTIONS)
     mutex1.lock.should be_true


### PR DESCRIPTION
Auto `reload` the `object` if `respond_to?(:reload)` to avoid calling `reload` on `ActiveRecord` objects after locking.
