### PR TITLE
Fix loop condition

### DIFF
--- a/lib/redis_mutex.rb
+++ b/lib/redis_mutex.rb
@@ -45,7 +45,7 @@ class RedisMutex < RedisClassy
     now = Time.now.to_f
     @expires_at = now + @expire                       # Extend in each blocking loop
 
-    loop do
+    begin
       return true if setnx(@expires_at)               # Success, the lock has been acquired
     end until old_value = get                         # Repeat if unlocked before get
 


### PR DESCRIPTION
The existing code means the until statement is only checked once before looping indefinitely, meaning if two clients call setnx at the same time one of them will loop until the lock is given up, regardless of the block setting.