### PR TITLE
chore: Require RSpec helper in .rspec config file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/spec/redis_mutex_macro_spec.rb
+++ b/spec/redis_mutex_macro_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class C
   include RedisMutex::Macro
   auto_mutex :run_singularly, :block => 0, :after_failure => lambda {|id| return "failure: #{id}" }

--- a/spec/redis_mutex_spec.rb
+++ b/spec/redis_mutex_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 SHORT_MUTEX_OPTIONS = { :block => 0.1, :sleep => 0.02 }
 
 describe RedisMutex do


### PR DESCRIPTION
This PR relies on the excellent configuration capacities of RSpec - require centrally what is used everywhere.