### PR TITLE
chore: Add CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/kenn/redis-mutex/actions/workflows/ci.yml/badge.svg)](https://github.com/kenn/redis-mutex/actions/workflows/ci.yml)
+
 Redis Mutex
 ===========
 


### PR DESCRIPTION
This PR adds a build status badge to the README.

After #47 we are green. 😀 